### PR TITLE
Fixed bfd_in.h and bfd_in2.h to fix compilation error

### DIFF
--- a/bfd/bfd-in.h
+++ b/bfd/bfd-in.h
@@ -510,7 +510,7 @@ extern void warn_deprecated (const char *, const char *, int, const char *);
 
 #define bfd_get_symbol_leading_char(abfd) ((abfd)->xvec->symbol_leading_char)
 
-#define bfd_set_cacheable(abfd,bool) (((abfd)->cacheable = bool), TRUE)
+#define bfd_set_cacheable(abfd,bool) ((abfd)->cacheable = bool)
 
 extern bfd_boolean bfd_cache_close
   (bfd *abfd);

--- a/bfd/bfd-in2.h
+++ b/bfd/bfd-in2.h
@@ -517,7 +517,7 @@ extern void warn_deprecated (const char *, const char *, int, const char *);
 
 #define bfd_get_symbol_leading_char(abfd) ((abfd)->xvec->symbol_leading_char)
 
-#define bfd_set_cacheable(abfd,bool) (((abfd)->cacheable = bool), TRUE)
+#define bfd_set_cacheable(abfd,bool) ((abfd)->cacheable = bool)
 
 extern bfd_boolean bfd_cache_close
   (bfd *abfd);


### PR DESCRIPTION
This was causing compile error on RHEL6 with gcc4.9.2. The fix solves this issue.
